### PR TITLE
fix: Configure production environment URLs for Railway deployment

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -5,6 +5,12 @@ RAILWAY_ENVIRONMENT=production
 NODE_ENV=production
 PORT=3001
 
+# CORS Configuration
+FRONTEND_URL=https://rasuki.up.railway.app
+
+# Security Configuration
+JWT_SECRET=your-production-jwt-secret-key-change-this-in-production
+
 # Database Configuration (Railway provides these automatically)
 # DATABASE_URL is auto-injected by Railway for linked PostgreSQL service
 

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,4 +1,4 @@
-# Railway Frontend Environment Variables - Updated to use staging backend
-REACT_APP_API_URL=https://carparts-backend-staging.up.railway.app
+# Railway Frontend Environment Variables - Production Configuration
+REACT_APP_API_URL=https://carparts-backend.up.railway.app
 GENERATE_SOURCEMAP=false
 CI=false


### PR DESCRIPTION
- Update frontend .env.production to use production backend URL
- Add FRONTEND_URL and JWT_SECRET to backend production environment
- Fix CORS configuration for production deployment
- Ensure frontend points to carparts-backend.up.railway.app instead of staging

This resolves the 'Failed to fetch' login error by properly configuring the frontend-backend communication URLs for production.